### PR TITLE
Remove node warnings

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -9,16 +9,6 @@ import {
   series,
 } from './lib/webpack';
 
-const currentNodeVersion = process.versions.node;
-if (currentNodeVersion.split('.')[0] < 6) {
-  console.error(chalk.white.bgRed(MSG.NODE()(currentNodeVersion)));
-  process.exit(1);
-}
-
-if (currentNodeVersion.split('.')[0] > 6) {
-  console.warn(chalk.white.bgRed(MSG.HNODE()(currentNodeVersion)));
-}
-
 const result = isValidExecute();
 if (result && !result.status) {
   console.error(chalk.white.bgRed(result.msg));

--- a/index.js
+++ b/index.js
@@ -19,16 +19,6 @@ var _package2 = _interopRequireDefault(_package);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-const currentNodeVersion = process.versions.node;
-if (currentNodeVersion.split('.')[0] < 6) {
-  console.error(_chalk2['default'].white.bgRed(_constants.MSG.NODE()(currentNodeVersion)));
-  process.exit(1);
-}
-
-if (currentNodeVersion.split('.')[0] > 6) {
-  console.warn(_chalk2['default'].white.bgRed(_constants.MSG.HNODE()(currentNodeVersion)));
-}
-
 const result = (0, _webpack.isValidExecute)();
 if (result && !result.status) {
   console.error(_chalk2['default'].white.bgRed(result.msg));


### PR DESCRIPTION
Removes node version warnings. As discussed with @sku146, version requirements, in case of any, will be provided in the client `package.json`, but not in the engine itself.